### PR TITLE
withheld_in_countries field became array of string, same as in tweet …

### DIFF
--- a/twitter_user.go
+++ b/twitter_user.go
@@ -42,7 +42,7 @@ type User struct {
 	URL                            string   `json:"url"` // From UTC in seconds
 	UtcOffset                      int      `json:"utc_offset"`
 	Verified                       bool     `json:"verified"`
-	WithheldInCountries            string   `json:"withheld_in_countries"`
+	WithheldInCountries            []string `json:"withheld_in_countries"`
 	WithheldScope                  string   `json:"withheld_scope"`
 }
 


### PR DESCRIPTION
withheld_in_countries field in user structure became an array of strings. Same as withheld_in_countries field in tweet. That brokes anakonda for me, but there is no any changes about it in documentation
